### PR TITLE
React.PropTypes と flow で型チェック

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "optional": [
+    "runtime",
+    "es7.asyncFunctions"
+  ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,9 @@
     "modules": true,
     "jsx": true
   },
+  "plugins": [
+    "react"
+  ],
   "rules": {
     "quotes": [2, "single"],
     "no-use-before-define": [2, "nofunc"]

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,11 @@
   "parser": "babel-eslint",
   "env": {
     "es6": true,
-    "jsx": true,
     "browser": true
   },
   "ecmaFeatures": {
-    "modules": true
+    "modules": true,
+    "jsx": true
   },
   "rules": {
     "quotes": [2, "single"],

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,10 +1,10 @@
 [ignore]
 .*/node_modules/webpack/.*
+.*/static/js/.*
 
 [include]
-../node_modules
 
 [libs]
-../assets/interfaces
+assets/interfaces
 
 [options]

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,10 @@
+[ignore]
+.*/node_modules/webpack/.*
+
+[include]
+../node_modules
+
+[libs]
+../assets/interfaces
+
+[options]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ or
 npm start
 ```
 
+Statically check common errors:
+
+```
+npm run eslint
+```
+
 Statically check types:
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ An API server for home brewery.
 - Node, NPM
 - Heroku Toolbelt (for deployment to Heroku)
 - MongoDB
+- [flow](http://flowtype.org/) (optional)
 
 ## Usage
 
@@ -77,6 +78,12 @@ or
 
 ```
 npm start
+```
+
+Statically check types:
+
+```
+npm run flow
 ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npm start
 Statically check types:
 
 ```
-npm run flow
+flow
 ```
 
 ## Test

--- a/assets/interfaces/fetch.js
+++ b/assets/interfaces/fetch.js
@@ -1,0 +1,7 @@
+declare class Response {
+  ok: boolean;
+  json(): Promise<Object>;
+  text(): Promise<string>;
+}
+
+declare function fetch(input: string, init?: Object): Promise<Response>;

--- a/assets/interfaces/fetch.js
+++ b/assets/interfaces/fetch.js
@@ -1,6 +1,6 @@
 declare class Response {
   ok: boolean;
-  json(): Promise<Object>;
+  json(): Promise<any>;
   text(): Promise<string>;
 }
 

--- a/assets/interfaces/models.js
+++ b/assets/interfaces/models.js
@@ -1,0 +1,10 @@
+type Datapoint = {
+  at: Date;
+  value: number;
+};
+
+type Channel = {
+  id: string;
+  name: string;
+  datapoints: Array<Datapoint>;
+};

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -1,10 +1,16 @@
+/* @flow */
+// JSX complication requires a reference to `React` and flow doesn't understand
+// `import React, { Component, PropTypes } from 'react';`.
 import React from 'react';
+const { Component, PropTypes } = React;
 import d3 from 'd3';
 import { LineChart } from 'react-d3-components';
-import { formatDateTime, formatDate, formatTime } from './date-utils';
 
-export class DatapointChart {
-  formatTick(d) {
+import { formatDateTime, formatDate, formatTime } from './date-utils';
+import { ChannelShape, DatapointShape } from './prop-types';
+
+export class DatapointChart extends Component {
+  formatTick(d: Date): string {
     const hours = d.getHours();
     if (hours === 0) {
       return formatDate(d);
@@ -13,7 +19,7 @@ export class DatapointChart {
     }
   }
 
-  render() {
+  render(): any {
     const values = this.props.datapoints.map((d) => {
       return { x: d.at, y: d.value };
     });
@@ -50,9 +56,13 @@ export class DatapointChart {
     );
   }
 }
+// TODO: Use `static get propTypes()` as soon as flow supports static getter.
+DatapointChart.propTypes = {
+  datapoints: PropTypes.arrayOf(DatapointShape)
+};
 
-export class Channel extends React.Component {
-  render() {
+export class Channel extends Component {
+  render(): any {
     const channel = this.props.channel;
     const url = `/channels/${channel.id}/datapoints`;
     const latest = channel.datapoints[channel.datapoints.length - 1];
@@ -70,9 +80,12 @@ export class Channel extends React.Component {
     );
   }
 }
+Channel.propTypes = {
+  channel: ChannelShape.isRequired
+};
 
-export class ChannelList extends React.Component {
-  render() {
+export class ChannelList extends Component {
+  render(): any {
     if (!this.props.channels) {
       return null;
     }
@@ -81,18 +94,24 @@ export class ChannelList extends React.Component {
     return <div className="channel-list">{listItems}</div>;
   }
 }
+ChannelList.propTypes = {
+  channels: PropTypes.arrayOf(ChannelShape).isRequired
+};
 
-export class ErrorMessage extends React.Component {
-  render() {
+export class ErrorMessage extends Component {
+  render(): any {
     if (!this.props.error) {
       return null;
     }
     return <p className="error-message">Failed to fetch data: {this.props.error.toString()}</p>;
   }
 }
+ErrorMessage.propTypes = {
+  channels: PropTypes.arrayOf(ChannelShape),
+};
 
-export class Dashboard extends React.Component {
-  render() {
+export class Dashboard extends Component {
+  render(): any {
     return (
       <div className="dashboard">
         <h1>Beerserver Dashboard</h1>

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -2,7 +2,7 @@
 // JSX complication requires a reference to `React` and flow doesn't understand
 // `import React, { Component, PropTypes } from 'react';`.
 import React from 'react';
-const { Component, PropTypes } = React;
+var { Component, PropTypes } = React;
 import d3 from 'd3';
 import { LineChart } from 'react-d3-components';
 
@@ -11,7 +11,7 @@ import { ChannelShape, DatapointShape } from './prop-types';
 
 export class DatapointChart extends Component {
   formatTick(d: Date): string {
-    const hours = d.getHours();
+    var hours = d.getHours();
     if (hours === 0) {
       return formatDate(d);
     } else {
@@ -20,27 +20,27 @@ export class DatapointChart extends Component {
   }
 
   render(): any {
-    const values = this.props.datapoints.map((d) => {
+    var values = this.props.datapoints.map((d) => {
       return { x: d.at, y: d.value };
     });
-    const data = { label: '', values };
+    var data = { label: '', values };
 
-    const width = 800;
-    const height = 200;
-    const margin = { top: 10, bottom: 20, left: 50, right: 20 };
+    var width = 800;
+    var height = 200;
+    var margin = { top: 10, bottom: 20, left: 50, right: 20 };
 
-    const xs = values.map((v) => v.x);
-    const minX = Math.min(...xs);
-    const maxX = Math.max(...xs);
+    var xs = values.map((v) => v.x);
+    var minX = Math.min(...xs);
+    var maxX = Math.max(...xs);
 
-    const xScale = d3.time.scale()
+    var xScale = d3.time.scale()
       .domain([minX, maxX])
       .range([0, width - margin.left - margin.right]);
-    const xAxis = { tickFormat: this.formatTick.bind(this) };
-    const yAxis = { label: 'Deg C' };
+    var xAxis = { tickFormat: this.formatTick.bind(this) };
+    var yAxis = { label: 'Deg C' };
 
-    const tooltipHtml = (_, data) => {
-      const date = formatDateTime(data.x);
+    var tooltipHtml = (_, data) => {
+      var date = formatDateTime(data.x);
       return `${data.y} at ${date}`;
     };
 
@@ -63,19 +63,30 @@ DatapointChart.propTypes = {
 
 export class Channel extends Component {
   render(): any {
-    const channel = this.props.channel;
-    const url = `/channels/${channel.id}/datapoints`;
-    const latest = channel.datapoints[channel.datapoints.length - 1];
-    const date = formatDateTime(latest.at);
+    var channel = this.props.channel;
+    var url = `/channels/${channel.id}/datapoints`;
+    var content;
+
+    if (channel.datapoints) {
+      var latest = channel.datapoints[channel.datapoints.length - 1];
+      var date = formatDateTime(latest.at);
+      content = (
+        <div>
+          <p>
+            <span className="latest">Latest: {latest.value} at {date}</span>
+            <span> </span>
+            <span className="json"><a href={url}>JSON</a></span>
+          </p>
+          <DatapointChart datapoints={channel.datapoints} />
+        </div>
+      );
+    } else {
+      content = <p className="loading">Loading...</p>;
+    }
     return (
       <div className="channel">
         <h2 className="name">{channel.name}</h2>
-        <p>
-          <span className="latest">Latest: {latest.value} at {date}</span>
-          <span> </span>
-          <span className="json"><a href={url}>JSON</a></span>
-        </p>
-        <DatapointChart datapoints={channel.datapoints} />
+        {content}
       </div>
     );
   }
@@ -90,7 +101,7 @@ export class ChannelList extends Component {
       return null;
     }
 
-    const listItems = this.props.channels.map((channel) => <Channel channel={channel} key={channel.id} />);
+    var listItems = this.props.channels.map((channel) => <Channel channel={channel} key={channel.id} />);
     return <div className="channel-list">{listItems}</div>;
   }
 }
@@ -107,7 +118,7 @@ export class ErrorMessage extends Component {
   }
 }
 ErrorMessage.propTypes = {
-  channels: PropTypes.arrayOf(ChannelShape),
+  error: PropTypes.instanceOf(Error)
 };
 
 export class Dashboard extends Component {
@@ -121,3 +132,7 @@ export class Dashboard extends Component {
     );
   }
 }
+Dashboard.propTypes = {
+  channels: PropTypes.arrayOf(ChannelShape),
+  error: PropTypes.instanceOf(Error)
+};

--- a/assets/js/components.js
+++ b/assets/js/components.js
@@ -39,9 +39,9 @@ export class DatapointChart extends Component {
     var xAxis = { tickFormat: this.formatTick.bind(this) };
     var yAxis = { label: 'Deg C' };
 
-    var tooltipHtml = (_, data) => {
-      var date = formatDateTime(data.x);
-      return `${data.y} at ${date}`;
+    var tooltipHtml = (_, d) => {
+      var date = formatDateTime(d.x);
+      return `${d.y} at ${date}`;
     };
 
     return (
@@ -106,7 +106,7 @@ export class ChannelList extends Component {
   }
 }
 ChannelList.propTypes = {
-  channels: PropTypes.arrayOf(ChannelShape).isRequired
+  channels: PropTypes.arrayOf(ChannelShape)
 };
 
 export class ErrorMessage extends Component {

--- a/assets/js/date-utils.js
+++ b/assets/js/date-utils.js
@@ -1,28 +1,28 @@
 /* @flow */
 
 export function formatDateTime(date: Date): string {
-  const year = date.getFullYear();
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
-  const hours = date.getHours();
-  const minutes = padZero(date.getMinutes());
+  var year = date.getFullYear();
+  var month = date.getMonth() + 1;
+  var day = date.getDate();
+  var hours = date.getHours();
+  var minutes = padZero(date.getMinutes());
   return `${year}/${month}/${day} ${hours}:${minutes}`;
 }
 
 export function formatDate(date: Date): string {
-  const month = date.getMonth() + 1;
-  const day = date.getDate();
+  var month = date.getMonth() + 1;
+  var day = date.getDate();
   return `${month}/${day}`;
 }
 
 export function formatTime(date: Date): string {
-  const hours = date.getHours();
-  const minutes = padZero(date.getMinutes());
+  var hours = date.getHours();
+  var minutes = padZero(date.getMinutes());
   return `${hours}:${minutes}`;
 }
 
 function padZero(num: number): string {
-  const str = num.toString();
+  var str = num.toString();
   if (str.length === 1) {
     return `0${str}`;
   } else {

--- a/assets/js/date-utils.js
+++ b/assets/js/date-utils.js
@@ -1,4 +1,6 @@
-export function formatDateTime(date) {
+/* @flow */
+
+export function formatDateTime(date: Date): string {
   const year = date.getFullYear();
   const month = date.getMonth() + 1;
   const day = date.getDate();
@@ -7,19 +9,19 @@ export function formatDateTime(date) {
   return `${year}/${month}/${day} ${hours}:${minutes}`;
 }
 
-export function formatDate(date) {
+export function formatDate(date: Date): string {
   const month = date.getMonth() + 1;
   const day = date.getDate();
   return `${month}/${day}`;
 }
 
-export function formatTime(date) {
+export function formatTime(date: Date): string {
   const hours = date.getHours();
   const minutes = padZero(date.getMinutes());
   return `${hours}:${minutes}`;
 }
 
-function padZero(num) {
+function padZero(num: number): string {
   const str = num.toString();
   if (str.length === 1) {
     return `0${str}`;

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,10 +1,10 @@
 /* @flow */
+/* global require */
 require('whatwg-fetch');
-// require('babel-runtime/core-js');
-// require('babel-runtime/regenerator');
 import React from 'react';
 
 import { Dashboard } from './components';
+import type { Channel } from './models';
 
 (async () => {
   try {
@@ -16,7 +16,6 @@ import { Dashboard } from './components';
       renderDashboard(channels);
     });
   } catch (e) {
-    console.error(e);
     renderError(e);
   }
 })();

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -1,4 +1,5 @@
-import 'whatwg-fetch';
+/* @flow */
+import _ from 'whatwg-fetch';
 import React from 'react';
 
 import { Dashboard } from './components';
@@ -7,21 +8,21 @@ fetchChannels()
   .then(renderDashboard)
   .catch(renderError);
 
-function fetchChannels() {
+function fetchChannels(): Promise<Array<Channel>> {
   return fetch('/channels')
-    .then((response) => {
+    .then((response: Response) => {
       if (response.ok) {
         return response.json();
       } else {
-        return response.text().then((t) => Promise.reject(new Error(t)));
+        return response.text().then((t: string) => Promise.reject(new Error(t)));
       }
     })
     .then((channels) => Promise.all(channels.map(fetchDatapoints)));
 }
 
-function fetchDatapoints(channel) {
+function fetchDatapoints(channel: Channel): Promise<Channel> {
   return fetch(`/channels/${channel.id}/datapoints`)
-    .then((response) => response.json())
+    .then((response: Response) => response.json())
     .then((datapoints) => {
       channel.datapoints = datapoints.map((d) => {
         return { at: new Date(d.at), value: d.value };
@@ -30,7 +31,7 @@ function fetchDatapoints(channel) {
     });
 }
 
-function renderDashboard(channels) {
+function renderDashboard(channels: Array<Channel>) {
   React.render(
     <Dashboard channels={channels} />,
     document.getElementById('world')

--- a/assets/js/models.js
+++ b/assets/js/models.js
@@ -1,9 +1,9 @@
-type Datapoint = {
+export type Datapoint = {
   at: Date;
   value: number;
 };
 
-type Channel = {
+export type Channel = {
   id: string;
   name: string;
   datapoints: Array<Datapoint>;

--- a/assets/js/prop-types.js
+++ b/assets/js/prop-types.js
@@ -1,13 +1,13 @@
 /* @flow */
 import { PropTypes } from 'react';
 
-export const DatapointShape = PropTypes.shape({
+export var DatapointShape = PropTypes.shape({
   at: PropTypes.instanceOf(Date).isRequired,
   value: PropTypes.number.isRequired
 });
 
-export const ChannelShape = PropTypes.shape({
+export var ChannelShape = PropTypes.shape({
   id: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
-  datapoints: PropTypes.arrayOf(DatapointShape).isRequired
+  datapoints: PropTypes.arrayOf(DatapointShape)
 });

--- a/assets/js/prop-types.js
+++ b/assets/js/prop-types.js
@@ -1,0 +1,13 @@
+/* @flow */
+import { PropTypes } from 'react';
+
+export const DatapointShape = PropTypes.shape({
+  at: PropTypes.instanceOf(Date).isRequired,
+  value: PropTypes.number.isRequired
+});
+
+export const ChannelShape = PropTypes.shape({
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  datapoints: PropTypes.arrayOf(DatapointShape).isRequired
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "npm run copy && webpack",
     "copy": "mkdir -p static && cp assets/index.html static/ && cp -r assets/css static/",
     "test": "echo \"Error: no test specified\" && exit 1",
+    "flow": "dir=`mktemp -d tmpXXXXXX` && cp .flowconfig $dir/ && babel --whitelist es6.constants,es6.blockScoping -d $dir assets/js/*.js && flow check $dir; rm -rf $dir",
     "postinstall": "npm run build"
   },
   "repository": {
@@ -30,6 +31,7 @@
     "whatwg-fetch": "^0.9.0"
   },
   "devDependencies": {
+    "babel": "^5.5.7",
     "babel-core": "^5.5.3",
     "babel-eslint": "^3.1.13",
     "babel-loader": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "npm run copy && watchify -t babelify assets/js/index.js -o static/js/index.js",
     "build": "npm run copy && browserify -t babelify assets/js/index.js -o static/js/index.js",
     "copy": "mkdir -p static/{js,css} && cp assets/index.html static/ && cp -r assets/css static/",
+    "eslint": "eslint assets/js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "npm run build"
   },
@@ -36,6 +37,8 @@
     "babelify": "^6.1.2",
     "browserify": "^10.2.4",
     "d3": "^3.5.5",
+    "eslint": "^0.22.1",
+    "eslint-plugin-react": "^2.5.0",
     "watchify": "^3.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,10 @@
   "version": "0.0.1",
   "description": "Cheers!",
   "scripts": {
-    "start": "npm run copy && webpack --watch",
-    "build": "npm run copy && webpack",
-    "copy": "mkdir -p static && cp assets/index.html static/ && cp -r assets/css static/",
+    "start": "npm run copy && watchify -t babelify assets/js/index.js -o static/js/index.js",
+    "build": "npm run copy && browserify -t babelify assets/js/index.js -o static/js/index.js",
+    "copy": "mkdir -p static/{js,css} && cp assets/index.html static/ && cp -r assets/css static/",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "flow": "dir=`mktemp -d tmpXXXXXX` && cp .flowconfig $dir/ && babel --whitelist es6.constants,es6.blockScoping -d $dir assets/js/*.js && flow check $dir; rm -rf $dir",
     "postinstall": "npm run build"
   },
   "repository": {
@@ -24,6 +23,7 @@
   },
   "homepage": "https://github.com/beergarden/beerserver",
   "dependencies": {
+    "babel-runtime": "^5.5.8",
     "flux": "^2.0.3",
     "node-libs-browser": "^0.5.2",
     "react": "^0.13.3",
@@ -31,11 +31,11 @@
     "whatwg-fetch": "^0.9.0"
   },
   "devDependencies": {
-    "babel": "^5.5.7",
-    "babel-core": "^5.5.3",
-    "babel-eslint": "^3.1.13",
-    "babel-loader": "^5.1.4",
+    "babel-core": "^5.5.8",
+    "babel-eslint": "^3.1.15",
+    "babelify": "^6.1.2",
+    "browserify": "^10.2.4",
     "d3": "^3.5.5",
-    "webpack": "^1.9.10"
+    "watchify": "^3.2.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,9 @@
 
 var path = require('path');
 
-var babelOptions = {};
+var babelOptions = {
+  optional: ['runtime', 'es7.asyncFunctions']
+};
 
 module.exports = {
   entry: './assets/js/index.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,11 +3,7 @@
 
 var path = require('path');
 
-var babelOptions = {
-  optional: [
-    'es7.asyncFunctions'
-  ]
-};
+var babelOptions = {};
 
 module.exports = {
   entry: './assets/js/index.js',


### PR DESCRIPTION
- [React.PropTypes](https://facebook.github.io/react/docs/reusable-components.html): ランタイムで Component に渡される props の型をチェック。
- [flow](http://flowtype.org/): ソースコードの静的型チェック。`brew install flow` しておいて `flow` で実行可能。

ついでに datapoints が読み込まれていなくても channel 一覧を先に表示するようにしました。
